### PR TITLE
Add friend priority and add the ability to set friend type after initializing Friend

### DIFF
--- a/src/main/java/com/github/fabricutilitymods/friendapi/Friend.java
+++ b/src/main/java/com/github/fabricutilitymods/friendapi/Friend.java
@@ -6,10 +6,18 @@ public final class Friend implements FriendData {
 
     public GameProfile gameProfile;
     public FriendType friendType;
+    public int priority;
 
     public Friend(GameProfile gameProfile, FriendType friendType) {
         this.gameProfile = gameProfile;
         this.friendType = friendType;
+        this.priority = 0;
+    }
+    
+    public Friend(GameProfile gameProfile, FriendType friendType, int priority) {
+        this.gameProfile = gameProfile;
+        this.friendType = friendType;
+        this.priority = priority;
     }
 
     @Override

--- a/src/main/java/com/github/fabricutilitymods/friendapi/Friend.java
+++ b/src/main/java/com/github/fabricutilitymods/friendapi/Friend.java
@@ -6,23 +6,10 @@ public final class Friend implements FriendData {
 
     public GameProfile gameProfile;
     public FriendType friendType;
-    /* 
-    * What priority this Friend has, by default this is 0, indicating no priority. Priority could be used as a way to sort Friends when
-    * needed and allow the user to choose who they want to have a higher and lower priority. If two friends have the same priority then it will be random.
-    * This isn't a necessity but could be a neat feature if you want to hook it into your client.
-    */
-    public int priority;
 
     public Friend(GameProfile gameProfile, FriendType friendType) {
         this.gameProfile = gameProfile;
         this.friendType = friendType;
-        this.priority = 0;
-    }
-    
-    public Friend(GameProfile gameProfile, FriendType friendType, int priority) {
-        this.gameProfile = gameProfile;
-        this.friendType = friendType;
-        this.priority = priority;
     }
 
     @Override
@@ -38,14 +25,5 @@ public final class Friend implements FriendData {
     @Override
     public void setType(FriendType friendType) {
         this.friendType = friendType;
-    }
-    
-    @Override
-    public int getPriority() {
-        return priority;
-    }
-    
-    public void setPriority(int priority) {
-        this.priority = priority;
     }
 }

--- a/src/main/java/com/github/fabricutilitymods/friendapi/Friend.java
+++ b/src/main/java/com/github/fabricutilitymods/friendapi/Friend.java
@@ -6,6 +6,11 @@ public final class Friend implements FriendData {
 
     public GameProfile gameProfile;
     public FriendType friendType;
+    /* 
+    * What priority this Friend has, by default this is 0, indicating no priority. Priority could be used as a way to sort Friends when
+    * needed and allow the user to choose who they want to have a higher and lower priority. If two friends have the same priority then it will be random.
+    * This isn't a necessity but could be a neat feature if you want to hook it into your client.
+    */
     public int priority;
 
     public Friend(GameProfile gameProfile, FriendType friendType) {
@@ -28,5 +33,19 @@ public final class Friend implements FriendData {
     @Override
     public FriendType getType() {
         return friendType;
+    }
+    
+    @Override
+    public void setType(FriendType friendType) {
+        this.friendType = friendType;
+    }
+    
+    @Override
+    public int getPriority() {
+        return priority;
+    }
+    
+    public void setPriority(int priority) {
+        this.priority = priority;
     }
 }

--- a/src/main/java/com/github/fabricutilitymods/friendapi/FriendData.java
+++ b/src/main/java/com/github/fabricutilitymods/friendapi/FriendData.java
@@ -8,4 +8,9 @@ public interface FriendData {
 
     FriendType getType();
 
+    void setType(FriendType type);
+    
+    int getPriority();
+    
+    void setPriority(int priority);
 }

--- a/src/main/java/com/github/fabricutilitymods/friendapi/FriendData.java
+++ b/src/main/java/com/github/fabricutilitymods/friendapi/FriendData.java
@@ -10,7 +10,4 @@ public interface FriendData {
 
     void setType(FriendType type);
     
-    int getPriority();
-    
-    void setPriority(int priority);
 }

--- a/src/main/java/com/github/fabricutilitymods/friendapi/FriendType.java
+++ b/src/main/java/com/github/fabricutilitymods/friendapi/FriendType.java
@@ -1,8 +1,14 @@
 package com.github.fabricutilitymods.friendapi;
 
 public enum FriendType {
-    ENEMY,
-    NEUTRAL,
-    FRIEND,
-    BEST_FRIEND
+    ENEMY(-1),
+    NEUTRAL(0),
+    FRIEND(1),
+    BEST_FRIEND(2);
+        
+    private final int priority;
+    
+    FriendType(int priority) {
+        this.priority = priority;
+    }
 }


### PR DESCRIPTION
I added friend priority which can be used as a way for other mods (if they'd like) to add a priority to a friend this way when selecting which friend should come first in some sort of operation it can be more logical. This can work along with FriendType where regardless of priority `BEST_FRIEND` always has a higher priority than `FRIEND`, and the opposite with `ENEMY` and `NEUTRAL`. I also added the ability to change the friend type of a player because that's pretty necessary. Priority is completely optional and doesn't have to be used by a mod unless it takes advantage of it